### PR TITLE
fix: trim network name

### DIFF
--- a/io/NetworkManager.qml
+++ b/io/NetworkManager.qml
@@ -7,7 +7,7 @@ import qs
 
 Singleton {
 	property bool connected: ethernetConnected || wifiConnected
-	property string network: ethernetNetwork || wifiNetwork
+	property string network: ethernetNetwork.trim() || wifiNetwork.trim()
 	property int strength: wifiStrength
 	property string ethernetNetwork: ""
 	property bool ethernetConnected: ethernetNetwork !== ""


### PR DESCRIPTION
Hi, ty for making your shell config public <3

A network name has trailing spaces when there are other networks in the output with longer names